### PR TITLE
Quick fix: corrects OBV Serial name

### DIFF
--- a/app/src/main/java/com/farmingdale/stockscreener/model/remote/OBVDataResponse.kt
+++ b/app/src/main/java/com/farmingdale/stockscreener/model/remote/OBVDataResponse.kt
@@ -8,7 +8,7 @@ data class OBVDataResponse(
     @SerialName("Meta Data")
     val metaData: MetaData,
 
-    @SerialName("OBV")
+    @SerialName("Technical Analysis: OBV")
     val technicalAnalysis: Map<String, Analysis>
 ) {
     @Serializable


### PR DESCRIPTION
OBVDataResponse now has correct serial name.

All Alpha Vantage technical analysis getters work as of 1/25/2024.